### PR TITLE
Add dialog view tracking to modal components

### DIFF
--- a/components/BuyCreditsDialog.vue
+++ b/components/BuyCreditsDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper :trackingTag="dialogTag">
         <div class="modal">
             <Subscription v-if="isStripFeatureEnable" />
             <BuyCredits v-else />
@@ -11,6 +11,9 @@
 const { getters } = authStore;
 const isStripFeatureEnable = computed(() => {
     return Boolean(unref(getters.user)?.isStripFeatureEnable);
+});
+const dialogTag = computed(() => {
+    return unref(isStripFeatureEnable) ? 'subscription' : 'buy_credits';
 });
 </script>
 

--- a/components/ChatSupport.vue
+++ b/components/ChatSupport.vue
@@ -60,6 +60,7 @@ import { iconType } from '~~/constants/icon.constants'
 import { sizeType } from '~~/constants/size.constants'
 import { themeType } from '~~/constants/theme.constants'
 import { ref, onMounted, onBeforeUnmount, unref } from 'vue'
+import { trackEvent } from '~~/utils/track'
 
 const supportDialog = useSupportDialog()
 
@@ -97,6 +98,8 @@ const sendMessage = async () => {
 }
 
 onMounted(() => {
+    trackEvent('dialog_view_support_chat')
+
     eventSource.value = new EventSource('/api/support/messages')
 
     unref(eventSource).onmessage = async (event) => {

--- a/components/DialogWrapper.vue
+++ b/components/DialogWrapper.vue
@@ -13,12 +13,17 @@
 <script setup>
 import { iconType } from '~~/constants/icon.constants';
 import { sizeType } from '~~/constants/size.constants';
-import { onMounted, onUnmounted } from 'vue';
+import { onMounted, onUnmounted, watch } from 'vue';
+import { trackEvent } from '~~/utils/track';
 
-const { isModalOpen } = defineProps({
+const { isModalOpen, trackingTag } = defineProps({
     isModalOpen: {
         type: Boolean,
         default: false,
+    },
+    trackingTag: {
+        type: String,
+        default: '',
     },
 })
 
@@ -27,6 +32,12 @@ const emit = defineEmits(["update:isModalOpen"]);
 const closeModal = () => {
     emit("update:isModalOpen", false);
 }
+
+watch(() => isModalOpen, (isOpen) => {
+    if (isOpen && Boolean(trackingTag)) {
+        trackEvent(`dialog_view_${trackingTag}`);
+    }
+});
 
 const handleKeydown = (event) => {
     if (event.key === 'Escape' && isModalOpen) {

--- a/components/FileModal.vue
+++ b/components/FileModal.vue
@@ -1,6 +1,6 @@
 <template>
-    <DialogWrapper>
-        <div class="modal">  
+    <DialogWrapper trackingTag="file">
+        <div class="modal">
             <div class="modal__wrapper">
                 <FileParts :class="partsClasses" :parts="fileModalData.parts" class="modal__parts"/>
                 <DxfViewerComponent

--- a/components/InfoAboutNestModal.vue
+++ b/components/InfoAboutNestModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="nest_info">
         <div class="modal">
             <MainTitle class="modal__title" label="Nesting in Progress" />
             <div class="modal__text text">

--- a/components/LoginView.vue
+++ b/components/LoginView.vue
@@ -1,7 +1,7 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="login">
         <div class="modal">
-            <MainTitle 
+            <MainTitle
                 label="Login to your account"
                 class="modal__title"
             />

--- a/components/ResultModal.vue
+++ b/components/ResultModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="result">
         <div class="modal">
             <div
                 v-if="resultModalData.isMultiSheet && !isHaveError"

--- a/components/ScreenshotsModal.vue
+++ b/components/ScreenshotsModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="screenshots">
         <div class="modal">
             <div class="modal__wrapper">
                 <div class="modal__controls controls">

--- a/components/StripFileModal.vue
+++ b/components/StripFileModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="strip_file">
         <div class="modal">
             <div class="modal__wrapper">
                 <DxfViewerComponent

--- a/components/StripResultModal.vue
+++ b/components/StripResultModal.vue
@@ -1,5 +1,5 @@
 <template>
-    <DialogWrapper>
+    <DialogWrapper trackingTag="strip_result">
         <div class="modal">
             <div class="modal__wrapper">
                 <DxfViewerComponent


### PR DESCRIPTION
## Summary
This PR adds event tracking for dialog/modal views across the application. When modals are opened, a tracking event is now fired to monitor user interactions with different dialog types.

## Key Changes
- **DialogWrapper.vue**: Added `trackingTag` prop and implemented a watcher that fires a `dialog_view_{trackingTag}` tracking event when the modal opens
- **Multiple modal components**: Updated all DialogWrapper usages to include appropriate `trackingTag` values:
  - `BuyCreditsDialog.vue`: Dynamic tag based on feature flag (`subscription` or `buy_credits`)
  - `FileModal.vue`: `file`
  - `LoginView.vue`: `login`
  - `InfoAboutNestModal.vue`: `nest_info`
  - `ResultModal.vue`: `result`
  - `ScreenshotsModal.vue`: `screenshots`
  - `StripFileModal.vue`: `strip_file`
  - `StripResultModal.vue`: `strip_result`
- **ChatSupport.vue**: Added direct tracking event call in `onMounted` hook for the support chat dialog

## Implementation Details
- The tracking is implemented via a Vue watcher on the `isModalOpen` prop that only fires when the modal opens and a tracking tag is provided
- The `BuyCreditsDialog` uses a computed property to dynamically determine the tracking tag based on the `isStripFeatureEnable` feature flag
- The `ChatSupport` component handles tracking separately since it doesn't use the DialogWrapper component
- All tracking events follow the naming convention: `dialog_view_{tagName}`

https://claude.ai/code/session_01Xka2u5BPXxzznRkisbir5Q